### PR TITLE
Pass down syntax errors to Webpack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,15 +65,23 @@ export default function (this: loader.LoaderContext, source: string) {
 
         let key = getTemplateHash(resourcePath);
         let sourceContext: TwingSource = new TwingSource(source, `${key}`);
-        let tokenStream: TwingTokenStream = environment.tokenize(sourceContext);
 
-        let module: TwingNodeModule = environment.parse(tokenStream);
+        let tokenStream: TwingTokenStream;
+        let nodeModule: TwingNodeModule;
+
+        try {
+            tokenStream = environment.tokenize(sourceContext);
+            nodeModule = environment.parse(tokenStream);
+        } catch (err) {
+            this.callback(err);
+            return null;
+        }
 
         let visitor = new Visitor(loader, resourcePath, getTemplateHash);
 
-        visitor.visit(module);
+        visitor.visit(nodeModule);
 
-        let precompiledTemplate = environment.compile(module);
+        let precompiledTemplate = environment.compile(nodeModule);
 
         parts.push(`let templatesModule = (() => {
 let module = {


### PR DESCRIPTION
This prevents Webpack from breaking in dev mode.

I am not familiar with the test suite, so I did not add a test for this new case. I could add some with some hints on how to set up tests for this.

Fix #26.